### PR TITLE
2025.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOSS_VER=0.4.9
 ARG PACKER_PROVISIONER_GOSS_VER=3
 ARG ALPINE_VERSION=3.18
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.24
 ARG PACKER_VERSION=1.12.0
 
 
@@ -10,10 +10,10 @@ FROM --platform=linux/arm64 golang:${GOLANG_VERSION} AS build_glibc_bins
 ENV GO111MODULE=on
 ARG GOSS_VER
 # Build goss for FreeBSD - arm64 - currently doesn't build, not sure if go problem or goss
-RUN GOOS=freebsd GOARCH=amd64 go install -ldflags "-X main.version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
-RUN GOOS=linux GOARCH=amd64 go install -ldflags "-X main.version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
-RUN GOOS=linux GOARCH=arm64 go install -ldflags "-X main.version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
-RUN go install -ldflags "-X main.version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER} && \
+RUN GOOS=freebsd GOARCH=amd64 go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
+RUN GOOS=linux GOARCH=amd64 go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
+RUN GOOS=linux GOARCH=arm64 go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER}
+RUN go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w" github.com/goss-org/goss/cmd/goss@v${GOSS_VER} && \
     go clean -cache -modcache
 
 # Build goss and packer-provisioner-goss with musl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GOSS_VER=0.4.9
 ARG PACKER_PROVISIONER_GOSS_VER=3
-ARG ALPINE_VERSION=3.18
+ARG ALPINE_VERSION=3.21
 ARG GOLANG_VERSION=1.24
 ARG PACKER_VERSION=1.12.0
 
@@ -24,7 +24,7 @@ ENV GO111MODULE=on
 ENV GOARCH=amd64
 RUN apk --no-cache --upgrade --virtual=build_environment add binutils git && \
     go install github.com/YaleUniversity/packer-provisioner-goss/v${PACKER_PROVISIONER_GOSS_VER}@latest && \
-    go install -ldflags "-X main.version=${GOSS_VER} -s -w"  github.com/goss-org/goss/cmd/goss@v${GOSS_VER} && \
+    go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w"  github.com/goss-org/goss/cmd/goss@v${GOSS_VER} && \
     go clean -cache -modcache && \
     apk --no-cache del build_environment
 
@@ -57,6 +57,7 @@ RUN apk --no-cache --upgrade --virtual=build_environment add \
     gcc python3-dev musl-dev libffi-dev openssl-dev && \
     apk --no-cache --upgrade --virtual=random_tools add \
     bash curl git gomplate jq netcat-openbsd python3 rsync &&\
+    python3 -m pip config set global.break-system-packages true && \
     pip3 --no-cache-dir install --upgrade awscli aws-sam-cli && \
     apk --no-cache del build_environment && \
     rm -rf /var/cache/apk/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 ARG GOSS_VER=0.4.9
-ARG PACKER_PROVISIONER_GOSS_VER=3
 ARG ALPINE_VERSION=3.21
 ARG GOLANG_VERSION=1.24
 ARG PACKER_VERSION=1.12.0
-
 
 # Build goss with glibc system
 FROM --platform=linux/arm64 golang:${GOLANG_VERSION} AS build_glibc_bins
@@ -18,12 +16,10 @@ RUN go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s
 
 # Build goss and packer-provisioner-goss with musl
 FROM --platform=linux/arm64 golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} as build_musl_bins
-ARG PACKER_PROVISIONER_GOSS_VER
 ARG GOSS_VER
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 RUN apk --no-cache --upgrade --virtual=build_environment add binutils git && \
-    go install github.com/YaleUniversity/packer-provisioner-goss/v${PACKER_PROVISIONER_GOSS_VER}@latest && \
     go install -ldflags "-X github.com/goss-org/goss/util.Version=${GOSS_VER} -s -w"  github.com/goss-org/goss/cmd/goss@v${GOSS_VER} && \
     go clean -cache -modcache && \
     apk --no-cache del build_environment
@@ -41,8 +37,7 @@ LABEL org.opencontainers.image.description="Hashicorp Packer packaged for GitLab
 RUN apk --no-cache --upgrade add py3-pip
 
 # Get binaries from musl based container
-COPY --from=build_musl_bins \
-    /go/bin/linux_amd64/goss /go/bin/linux_amd64/packer-provisioner-goss /bin/
+COPY --from=build_musl_bins /go/bin/linux_amd64/goss /bin/
 
 # Get binaries from glibc based container
 COPY --from=build_glibc_bins /go/bin/goss /bin/goss-glibc-arm64
@@ -67,6 +62,8 @@ RUN apk --no-cache --upgrade --virtual=build_environment add \
 RUN curl -L https://raw.githubusercontent.com/aelsabbahy/goss/master/extras/dgoss/dgoss -o /bin/dgoss && \
     chmod +x /bin/dgoss
 
-# Install packer config and run its initialization, which will pull required modules
+# Install packer config and run its initialization, which will pull required modules:
+# - packer-provisioner-goss
+# - aws
 COPY config.pkr.hcl /root/
 RUN packer init /root/config.pkr.hcl

--- a/config.pkr.hcl
+++ b/config.pkr.hcl
@@ -1,9 +1,14 @@
 packer {
-  required_plugins {
-    amazon = {
-      version = ">= 0.0.1"
-      source  = "github.com/hashicorp/amazon"
-    }
-  }
-}
+    required_version = ">= 1.9.0"
 
+    required_plugins {
+        amazon = {
+            version = ">= 0.0.1"
+            source  = "github.com/hashicorp/amazon"
+        }
+        goss = {
+            version = "~> 3"
+            source  = "github.com/YaleUniversity/goss"
+        }
+    }
+}


### PR DESCRIPTION
Updated all of the components:

- packer
- goss
- packer-goss-provisioner
- golang
- alpine

Changed install process for:
- goss: old style ldflags resulted in missing '--version' switch, which broke our linting
- packer-goss-provisioner: starting in packer 1.10 plugin install is done through a different process. It required upstream changes, which were lagging behind. They're in place now, so a config file can be used with `packer init`